### PR TITLE
Reduce the backoff duration of failed certificate

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,13 +52,12 @@ git_repository(
     remote = "https://github.com/kubernetes/repo-infra.git",
     shallow_since = "1569300445 -0700",
 )
-
-## Load rules_docker and depdencies, for working with docker images
-git_repository(
+## Load rules_docker and dependencies, for working with docker images
+http_archive(
     name = "io_bazel_rules_docker",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "80ea3aae060077e5fe0cdef1a5c570d4b7622100",
-    shallow_since = "1561646721 -0700",
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+    strip_prefix = "rules_docker-0.14.4",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
 )
 
 load(
@@ -68,14 +67,19 @@ load(
 
 container_repositories()
 
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
 )
-load(
-    "@io_bazel_rules_docker//go:image.bzl",
-    _go_image_repos = "repositories",
-)
+load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()
 

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -411,7 +411,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 	// time. If the failure time doesn't exist or is over an hour in the past
 	// then delete the request so it can be re-created on the next sync. If the
 	// failure time is less than an hour in the past then schedule this owning
-	// Certificate for a re-sync in an hour.
+	// Certificate for a re-sync in a minute.
 	case cmapi.CertificateRequestReasonFailed:
 		if existingReq.Status.FailureTime == nil || c.clock.Since(existingReq.Status.FailureTime.Time) > time.Minute {
 			log.Info("deleting failed certificate request")
@@ -433,7 +433,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 		}
 
 		// We don't fire an event here as this could be called multiple times in quick succession
-		c.scheduledWorkQueue.Add(key, time.Hour)
+		c.scheduledWorkQueue.Add(key, time.Minute)
 		return nil
 
 		// If the CertificateRequest is in a Ready state then we can decode,

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -413,7 +413,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 	// failure time is less than an hour in the past then schedule this owning
 	// Certificate for a re-sync in an hour.
 	case cmapi.CertificateRequestReasonFailed:
-		if existingReq.Status.FailureTime == nil || c.clock.Since(existingReq.Status.FailureTime.Time) > time.Hour {
+		if existingReq.Status.FailureTime == nil || c.clock.Since(existingReq.Status.FailureTime.Time) > time.Minute {
 			log.Info("deleting failed certificate request")
 			err := c.cmClient.CertmanagerV1alpha2().CertificateRequests(existingReq.Namespace).Delete(existingReq.Name, nil)
 			if err != nil {
@@ -424,7 +424,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 			return nil
 		}
 
-		log.Info("the failed existing certificate request failed less than an hour ago, will be scheduled for reprocessing in an hour")
+		log.Info("the failed existing certificate request failed less than a minute ago, will be scheduled for reprocessing in an minute")
 
 		key, err := keyFunc(crt)
 		if err != nil {

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -1079,7 +1079,7 @@ func TestProcessCertificate(t *testing.T) {
 				ExpectedEvents: []string{`Normal CertificateRequestRetry The failed CertificateRequest "test-850937773" will be retried now`},
 			},
 		},
-		"if a temporary certificate exists but the request has failed and contains a FailureTime over an hour in the past, delete the request to cause a re-sync and retry": {
+		"if a temporary certificate exists but the request has failed and contains a FailureTime over a minute in the past, delete the request to cause a re-sync and retry": {
 			certificate: exampleBundle1.certificate,
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
@@ -1102,7 +1102,7 @@ func TestProcessCertificate(t *testing.T) {
 					exampleBundle1.certificate,
 					gen.CertificateRequestFrom(exampleBundle1.certificateRequestFailed,
 						gen.SetCertificateRequestFailureTime(metav1.Time{
-							Time: fixedClockStart.Add(-time.Minute * 61),
+							Time: fixedClockStart.Add(-time.Second * 61),
 						})),
 				},
 				ExpectedActions: []testpkg.Action{
@@ -1115,7 +1115,7 @@ func TestProcessCertificate(t *testing.T) {
 				ExpectedEvents: []string{`Normal CertificateRequestRetry The failed CertificateRequest "test-850937773" will be retried now`},
 			},
 		},
-		"if a temporary certificate exists but the request has failed and contains a FailureTime less than an hour in the past, reschedule a re-sync in an hour": {
+		"if a temporary certificate exists but the request has failed and contains a FailureTime less than a minute in the past, reschedule a re-sync in a minute": {
 			certificate: exampleBundle1.certificate,
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
@@ -1138,7 +1138,7 @@ func TestProcessCertificate(t *testing.T) {
 					exampleBundle1.certificate,
 					gen.CertificateRequestFrom(exampleBundle1.certificateRequestFailed,
 						gen.SetCertificateRequestFailureTime(metav1.Time{
-							Time: fixedClockStart.Add(-time.Minute * 59),
+							Time: fixedClockStart.Add(-time.Second * 59),
 						})),
 				},
 				ExpectedActions: []testpkg.Action{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Reduce the backoff duration of failed certificate

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Reduce the backoff duration of failed certificate
```
